### PR TITLE
fix: remove red background on Rouge error tokens in code blocks

### DIFF
--- a/assets/css/jekyll-theme-chirpy.scss
+++ b/assets/css/jekyll-theme-chirpy.scss
@@ -27,12 +27,8 @@
 
 /* Prevent Rouge error token background from showing as red blocks. */
 .highlight .err,
-.highlighter-rouge .err,
-pre .err,
-code .err {
+.highlighter-rouge .err {
   background: transparent !important;
-  color: inherit !important;
-  border: 0 !important;
-  box-shadow: none !important;
+  border: none !important;
 }
 


### PR DESCRIPTION
- Override .err token styling to prevent red background on invalid syntax
- Add inline comment to highlight critical finding in semantic-release post